### PR TITLE
Update GATT characteristics code to match modern ESPHome properties.

### DIFF
--- a/components/rcxazair/rcxazair.cpp
+++ b/components/rcxazair/rcxazair.cpp
@@ -41,7 +41,7 @@ void Rcxazair::gattc_event_handler(
       }
       ESP_LOGI(TAG, "[%s] got characteristic!",
               this->parent_->address_str().c_str());
-      auto status = esp_ble_gattc_register_for_notify(this->parent_->gattc_if, this->parent_->remote_bda, chr->handle);
+      auto status = esp_ble_gattc_register_for_notify(this->parent()->get_gattc_if(), this->parent()->get_remote_bda(), chr->handle);
       if (status) {
         ESP_LOGE(TAG, "[%s] esp_ble_gattc_register_for_notify failed, status=%d",
                 this->parent_->address_str().c_str(),


### PR DESCRIPTION
The current source code doesn't compile against a recent ESPHome build (v2023.9.0). Some small changes will get it compiling and functioning.

* direct `parent_` references were replaced with `parent()`
* direct `gattc_if` references were replaced with `get_gattc_if()`
* direct `remote_bda` references were replaced with `get_remote_bda()`