### PR TITLE
0x23081007 message type support for PM sensors

### DIFF
--- a/components/rcxazair/rcxazair.cpp
+++ b/components/rcxazair/rcxazair.cpp
@@ -112,6 +112,22 @@ void Rcxazair::handle_message(uint8_t *msg, uint16_t len)
                 this->hcho_sensor_->publish_state(hcho);
             }
             break;
+        case 0x23081007:
+            if (len < 10)
+                return;
+            if (this->pmc_1_0_sensor_) {
+                uint16_t pmc_1_0_ugm3 = u16(4);
+                this->pmc_1_0_sensor_->publish_state(pmc_1_0_ugm3);
+            }
+            if (this->pmc_2_5_sensor_) {
+                uint16_t pmc_2_5_ugm3 = u16(6);
+                this->pmc_2_5_sensor_->publish_state(pmc_2_5_ugm3);
+            }
+            if (this->pmc_10_0_sensor_) {
+                uint16_t pmc_10_0_ugm3 = u16(8);
+                this->pmc_10_0_sensor_->publish_state(pmc_10_0_ugm3);
+            }
+            break;
         default:
         ESP_LOGI(TAG, "[%s] Got unknown message type %x",
                 this->parent_->address_str().c_str(),

--- a/components/rcxazair/rcxazair.h
+++ b/components/rcxazair/rcxazair.h
@@ -28,6 +28,9 @@ class Rcxazair : public esphome::ble_client::BLEClientNode
   void set_co2_sensor(sensor::Sensor *s) { co2_sensor_ = s; }
   void set_tvoc_sensor(sensor::Sensor *s) { tvoc_sensor_ = s; }
   void set_hcho_sensor(sensor::Sensor *s) { hcho_sensor_ = s; }
+  void set_pmc_1_0_sensor(sensor::Sensor *s) { pmc_1_0_sensor_ = s; }
+  void set_pmc_2_5_sensor(sensor::Sensor *s) { pmc_2_5_sensor_ = s; }
+  void set_pmc_10_0_sensor(sensor::Sensor *s) { pmc_10_0_sensor_ = s; }
 
  protected:
   void handle_message(uint8_t *msg, uint16_t len);
@@ -37,6 +40,9 @@ class Rcxazair : public esphome::ble_client::BLEClientNode
   sensor::Sensor *co2_sensor_{nullptr};
   sensor::Sensor *tvoc_sensor_{nullptr};
   sensor::Sensor *hcho_sensor_{nullptr};
+  sensor::Sensor *pmc_1_0_sensor_{nullptr};
+  sensor::Sensor *pmc_2_5_sensor_{nullptr};
+  sensor::Sensor *pmc_10_0_sensor_{nullptr};
 };
 
 }  // namespace rcxazair

--- a/components/rcxazair/sensor.py
+++ b/components/rcxazair/sensor.py
@@ -3,6 +3,7 @@ import esphome.config_validation as cv
 from esphome.components import sensor, ble_client
 from esphome.const import (
     CONF_ID,
+    STATE_CLASS_MEASUREMENT,
     #CONF_BATTERY_LEVEL,
     #DEVICE_CLASS_BATTERY,
     #ENTITY_CATEGORY_DIAGNOSTIC,
@@ -24,8 +25,22 @@ from esphome.const import (
     CONF_FORMALDEHYDE,
     UNIT_MICROGRAMS_PER_CUBIC_METER,
     ICON_CHEMICAL_WEAPON,
+
+    CONF_PM_1_0,
+    #CONF_PM_1_0UM,
+    DEVICE_CLASS_PM1,
+
+    CONF_PM_2_5,
+    #CONF_PM_2_5UM,
+    DEVICE_CLASS_PM25,
+
+    CONF_PM_10_0,
+    #CONF_PM_10_0UM,
+    DEVICE_CLASS_PM10,
+
 )
 
+ICON_MOLECULE = "mdi:molecule"
 CODEOWNERS = ["@mheistermann"]
 
 rcxazair_ns = cg.esphome_ns.namespace("rcxazair")
@@ -66,6 +81,27 @@ CONFIG_SCHEMA = (
                 icon=ICON_CHEMICAL_WEAPON,
                 accuracy_decimals=0,
             ),
+            cv.Optional(CONF_PM_1_0): sensor.sensor_schema(
+                unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
+                icon=ICON_MOLECULE,
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_PM1,
+                state_class=STATE_CLASS_MEASUREMENT
+            ),
+            cv.Optional(CONF_PM_2_5): sensor.sensor_schema(
+                unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
+                icon=ICON_MOLECULE,
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_PM25,
+                state_class=STATE_CLASS_MEASUREMENT
+            ),
+            cv.Optional(CONF_PM_10_0): sensor.sensor_schema(
+                unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
+                icon=ICON_MOLECULE,
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_PM10,
+                state_class=STATE_CLASS_MEASUREMENT
+            ),
         }
     )
     .extend(ble_client.BLE_CLIENT_SCHEMA)
@@ -100,4 +136,16 @@ def to_code(config):
     if CONF_HUMIDITY in config:
         sens = yield sensor.new_sensor(config[CONF_HUMIDITY])
         cg.add(var.set_relhum_sensor(sens))
+
+    if CONF_PM_1_0 in config:
+        sens = yield sensor.new_sensor(config[CONF_PM_1_0])
+        cg.add(var.set_pmc_1_0_sensor(sens))
+
+    if CONF_PM_2_5 in config:
+        sens = yield sensor.new_sensor(config[CONF_PM_2_5])
+        cg.add(var.set_pmc_2_5_sensor(sens))
+
+    if CONF_PM_10_0 in config:
+        sens = yield sensor.new_sensor(config[CONF_PM_10_0])
+        cg.add(var.set_pmc_10_0_sensor(sens))
 


### PR DESCRIPTION
This is a minimal set of changes needed to add support for PM sensors on RCXAZ air quality sensors which include particulate matter sensor values.

I honestly can't say for sure if this starts in 9-in-1 or 11-in-1 models because they count things like clocks and calendars in the number of available "sensors".

It appears that models with newer sensors just send the data from the added sensors in different message types. This means newer models will share sensor message formatting for previously-supported sensors. There's no guarantee it'll always work this way, but it's helpful as is.

One interesting thing to note is that ESPHome constants include ICON_MOLECULE_CO2 but not ICON_MOLECULE for some reason.